### PR TITLE
Fix: Merge nested if statements (SonarQube S1066)

### DIFF
--- a/Sources/DocScanCLI/DocScanCommand.swift
+++ b/Sources/DocScanCLI/DocScanCommand.swift
@@ -186,10 +186,8 @@ struct DocScanCommand: AsyncParsableCommand {
             if let field = extraction.secondaryField {
                 print("   \(secondaryFieldName): \(field)")
             }
-            if documentType == .prescription {
-                if let patient = extraction.patientName {
-                    print("   Patient: \(patient)")
-                }
+            if documentType == .prescription, let patient = extraction.patientName {
+                print("   Patient: \(patient)")
             }
             throw ExitCode.failure
         }


### PR DESCRIPTION
## Summary
- Merges nested if statement at line 189 in `DocScanCommand.swift`
- Combines `documentType == .prescription` check with `let patient = extraction.patientName` using Swift's comma syntax
- Resolves SonarQube rule S1066 ("Merge this if statement with the nested one")

## Changes
```swift
// Before
if documentType == .prescription {
    if let patient = extraction.patientName {
        print("   Patient: \(patient)")
    }
}

// After  
if documentType == .prescription, let patient = extraction.patientName {
    print("   Patient: \(patient)")
}
```

## Test plan
- [x] All existing tests pass (`swift test`)
- [x] SonarQube Cloud analysis should pass without the S1066 code smell

🤖 Generated with [Claude Code](https://claude.com/claude-code)